### PR TITLE
Show extended public key QR

### DIFF
--- a/kaspaperlib/wallet.go
+++ b/kaspaperlib/wallet.go
@@ -54,12 +54,25 @@ func (w *wallet) Address(index int) (string, error) {
 	}
 	return address.String(), nil
 }
+func (w *wallet) KPubKey() (string) {
+	return w.keysFile.ExtendedPublicKeys[0]
+}
 
 func (w *wallet) AddressQR(index int) ([]byte, error) {
 	address, err := w.Address(index)
 	if err != nil {
 		return nil, err
 	}
+
+	qr, err := qrcode.Encode(address, qrcode.High, 256)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return qr, nil
+}
+
+func (w *wallet) KPubKeyQR() ([]byte, error) {
+	address := w.KPubKey()
 
 	qr, err := qrcode.Encode(address, qrcode.High, 256)
 	if err != nil {

--- a/model/api.go
+++ b/model/api.go
@@ -8,4 +8,6 @@ type KaspaperWallet interface {
 	Mnemonic() *MnemonicString
 	Address(index int) (string, error)
 	AddressQR(index int) ([]byte, error)
+	KPubKey()(string)
+	KPubKeyQR() ([]byte, error)
 }

--- a/template.go
+++ b/template.go
@@ -16,6 +16,8 @@ type walletTemplate struct {
 	Mnemonic  *model.MnemonicString
 	Address   string
 	AddressQR string
+	KPubKey string
+	KPubKeyQR string
 }
 
 func renderWallet(wallet model.KaspaperWallet) (string, error) {
@@ -53,9 +55,21 @@ func walletToWalletTempalte(wallet model.KaspaperWallet) (*walletTemplate, error
 	}
 	addressQRBase64 := base64.StdEncoding.EncodeToString(addressQRbytes)
 
+
+	kpubKeyQRbytes, err := wallet.KPubKeyQR()
+	if err != nil {
+		return nil, err
+	}
+	kpubKeyBase64 := base64.StdEncoding.EncodeToString(kpubKeyQRbytes)
+	kpubKey := wallet.KPubKey();
+
+
+
 	return &walletTemplate{
 		Mnemonic:  wallet.Mnemonic(),
 		Address:   address,
 		AddressQR: addressQRBase64,
+		KPubKey : kpubKey,
+		KPubKeyQR: kpubKeyBase64,
 	}, nil
 }

--- a/template.html
+++ b/template.html
@@ -87,28 +87,34 @@
                 font-size: 20pt
             }
 
-            .QR {
-                float:left;
+            p.address{
+                font-family: 'Courier New', Courier, monospace;
+                font-weight: bolder;
+                word-wrap: break-word;
             }
-
-            .addr {
-                float: right;
-                font-family: monospace;
-                font-size: 30pt;
-                margin-top: 10px;
-                margin-right: 50px;
-                text-align: right;
-            }
-
             #QR {
                 outline: 5px solid black;
                 outline-offset: -15px;
-                margin-left: 50px;
+                margin-left: 60px;
+                width: 224px;
             }
 
+            .QR-item {
+	            padding-right: 80px;
+                float: left;  
+                margin-top: 5px;
+            }
+            .QR-header {
+                margin-left: 70px;
+                font-size: 20px;
+            }
             #url {
                 margin-top : -45px;
                 margin-left: 300px;
+            }
+            .container{ 
+                float:left; 
+                width:100%; 
             }
             
         </style>
@@ -142,7 +148,10 @@ AS<span style="font-family:Brush Script MT, Brush Script Std, cursive">PAPER</sp
                 <strong>https://github.com/svarogg/kaspaper</strong>.
             </p>
             <div>
-                <p style="font-family: 'Courier New', Courier, monospace; font-weight: bolder;"> {{.Address}}</p>
+                <p class="address"> 
+                    {{.Address}}
+                    {{.KPubKey}}
+                </p>
                 <h2>Private Key (KEEP PRIVATE!)</h2>
                 <ol id="mnemonic">
                     {{range .Mnemonic}}
@@ -159,15 +168,19 @@ AS<span style="font-family:Brush Script MT, Brush Script Std, cursive">PAPER</sp
                 </h1>
                 
                 <p id = "url">https://github.com/svarogg/kaspaper</p>
-                <div class = "QR">
-                    <img id = "QR" src="data:image/png;base64, {{.AddressQR}}" alt="Address QR" />
-                </div>
-                <div class="addr">         
-                    {{sub .Address 0 18}}<br>
-                    {{sub .Address 18 30}}<br>
-                    {{sub .Address 30 42}}<br>
-                    {{sub .Address 42 54}}<br>
-                    {{sub .Address 54 67}}<br>
+                <div class='container'>
+                    <div class = "QR-item">
+                        <span class="QR-header">Public Address</span>
+                        <div>
+                            <img id = "QR" src="data:image/png;base64, {{.AddressQR}}" alt="Address QR" />
+                        </div>
+                    </div>
+                    <div class = "QR-item">
+                        <span class="QR-header">Extended Public Key</span>
+                        <div>
+                            <img id = "QR" src="data:image/png;base64, {{.KPubKeyQR}}" alt="Extended Address QR" />
+                        </div>
+                    </div>
                 </div>
             </div>
         </page>


### PR DESCRIPTION
Show extended public key QR in Kaspa paper.
It is very useful when using 'watch only' wallet, simply scan the QR code to import the public extended key into the wallet